### PR TITLE
fix: max_min_f0 now accomodates 1D and irregular arrays

### DIFF
--- a/tests/test_pitch_process.py
+++ b/tests/test_pitch_process.py
@@ -60,3 +60,15 @@ def test_interp():
     assert (interp.shape == result.shape) 
     # below throws hard to understand error if the arrays are not the same size
     assert (interp == result).all()
+
+def test_min_max_f0():
+    # 1D array
+    arr = np.array([100,1,2,3,4,5,np.nan])
+    expected_max, expected_min = 100, 1
+    result_max, result_min = pp.max_min_f0(arr)
+    assert (expected_max, expected_min == result_max, result_min)
+
+    # irregular array
+    irregular_arr = np.array([[100,1,2,3,4,5,np.nan], [1,np.nan], []], dtype=object)
+    result_max, result_min = pp.max_min_f0(irregular_arr)
+    assert (expected_max, expected_min == result_max, result_min)

--- a/tonami/pitch_process.py
+++ b/tonami/pitch_process.py
@@ -229,10 +229,7 @@ def max_min_f0(pitch_contours: npt.NDArray[float]):
         float: speaker's upper limit on pitch
         float : speaker's lower limit on pitch
     """
-    flattened = pitch_contours
-    if pitch_contours.ndim > 1:
-        # turn into 1D array
-        flattened = np.hstack(pitch_contours)
+    flattened = np.hstack(pitch_contours)
     pitch_max = np.nanpercentile(flattened, 95)
     pitch_min = np.nanpercentile(flattened, 5)
     return pitch_max, pitch_min


### PR DESCRIPTION
Previously I was experiencing issues with getting min and max from 1D arrays, which is why I was trying to dimension check before flattening. Apparently it's not an issue anymore though - localhost works fine