### PR TITLE
Migrate app to Render instead of Heroku

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,6 +1,6 @@
-FROM python:3.9.7-slim-buster
+FROM python:3.11-slim-bookworm
 
-RUN apt-get update && apt-get -y install python3-pip ffmpeg
+RUN apt-get update && apt-get -y install python3-pip ffmpeg git
 WORKDIR /app
 
 # COPY data/forvo_zh_好玩.mp3 data/forvo_zh_好玩.mp3
@@ -14,4 +14,4 @@ COPY tonami_interface.py tonami_interface.py
 COPY data/parsed/toneperfect_pitch_librosa_50-500-fminmax.json data/parsed/toneperfect_pitch_librosa_50-500-fminmax.json
 
 
-CMD ["sh", "-c", "streamlit run --server.port $PORT tonami_interface.py"]
+CMD ["sh", "-c", "streamlit run tonami_interface.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: mount-files build-image push-image pull-image jupyter-server heroku-server lint
+.PHONY: mount-files build-image push-image pull-image jupyter-server heroku-server lint build-app
 
 IMAGE_NAME:=saltyseadawg/tonami-package
 IMAGE_VERSION:=latest
@@ -20,7 +20,7 @@ jupyter-server:
 	docker run -it -p 8888:8888 -v $(PWD)/:/app/ $(IMAGE_NAME):$(IMAGE_VERSION)
 
 heroku-server:
-	docker run -it -p 8501:8501 -v $(PWD)/:/app/ $(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash -c \
+	docker run -it -p 8501:8501 -v $(PWD)/:/app/ saltyseadawg/tonami-app:$(IMAGE_VERSION) /bin/bash -c \
 	"streamlit run tonami_interface.py"
 
 # code formatting
@@ -40,11 +40,11 @@ test-container:
 	"python -m pytest tests/"
 
 # release commands
-build-heroku:
-	docker build -f Dockerfile.heroku -t registry.heroku.com/tonami-testing/web .
+build-app:
+	docker build -f Dockerfile.app -t saltyseadawg/tonami-app:latest .
 
-push-heroku:
-	docker push registry.heroku.com/tonami-testing/web
+push-app:
+	docker push saltyseadawg/tonami-app:latest
 
 image-id:
 	docker inspect --format="{{.Id}}" registry.heroku.com/tonami-testing/web

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Tonami Package
-Python package for the Tonami web application backend
+# Tonami Demo
+Web app POC for practicing Mandarin tones
+Try it here: https://tonami-app.onrender.com/
 
 # Onboarding
 https://docs.google.com/document/d/1r_aaphKmehR05VFCEpNYpRURu5vr3gstXbSZiYwm3s8/edit?usp=sharing

--- a/heroku/interface_utils.py
+++ b/heroku/interface_utils.py
@@ -2,7 +2,7 @@ import os
 
 import streamlit as st
 import numpy as np
-from azure.storage.blob import ContentSettings
+# from azure.storage.blob import ContentSettings
 
 CONTAINER_NAME = os.getenv('CONTAINER_NAME')
 
@@ -31,8 +31,8 @@ def get_rating(rating_meta, target_tone, clf_probs):
     #         return rating["label"]
     # return rating[-1]["label"] 
 
-def upload_file(blob_service_client, filename):
-    content_setting = ContentSettings(content_type='audio/mp3')
-    blob_client = blob_service_client.get_blob_client(container=CONTAINER_NAME, blob=filename)
-    with open(filename, 'rb') as data:
-        blob_client.upload_blob(data, content_settings=content_setting)
+# def upload_file(blob_service_client, filename):
+#     content_setting = ContentSettings(content_type='audio/mp3')
+#     blob_client = blob_service_client.get_blob_client(container=CONTAINER_NAME, blob=filename)
+#     with open(filename, 'rb') as data:
+#         blob_client.upload_blob(data, content_settings=content_setting)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,12 +1,12 @@
 # Packages required to run 
-librosa==0.8.1
-praat-parselmouth==0.4.0
-streamlit==1.5.0
-scikit-learn==1.0.2
-streamlit-webrtc==0.35.0 # record audio files
+librosa==0.10.1
+praat-parselmouth==0.4.3
+streamlit==1.29.0
+scikit-learn==1.3.2
+streamlit-webrtc==0.47.1 # record audio files
 dnspython==2.0.0
 pydub==0.25.1 # audio manipulation
-azure-storage-blob==12.9.0 # packages for Azure storage
+# azure-storage-blob==12.9.0 # packages for Azure storage
 matplotlib==3.5.1
 
 # heroku may need numpy to run, however adding it produces the error "Cannot install 'llvmlite'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall."

--- a/tonami_interface.py
+++ b/tonami_interface.py
@@ -17,7 +17,7 @@ from tonami import user as usr
 from tonami import controller as cont
 from tonami import Classifier as c
 from heroku.interface_utils import *
-from azure.storage.blob import BlobServiceClient
+# from azure.storage.blob import BlobServiceClient
 
 
 import json
@@ -28,7 +28,7 @@ from tonami.audio_utils import convert_audio
 CONNECT_STR = os.getenv('AZURE_STORAGE_CONNECTION_STRING')
 EXERCISE_DIR = 'data/tone_perfect/'
 
-st.session_state.blob_service_client = BlobServiceClient.from_connection_string(CONNECT_STR)
+# st.session_state.blob_service_client = BlobServiceClient.from_connection_string(CONNECT_STR)
 
 # if not hasattr(st, "client"):
 #     st.client = pymongo.MongoClient(**st.secrets["mongo"])
@@ -110,7 +110,7 @@ else:
         # user_bytes = convert_audio(st.session_state.user_audio, 'wav').getvalue()
         # with open(st.session_state.user_audio, 'rb') as f:
         #     user_audio_bytes = f.read()
-        upload_file(st.session_state.blob_service_client, st.session_state.user_audio)
+        # upload_file(st.session_state.blob_service_client, st.session_state.user_audio)
         st.audio(st.session_state.user_audio, format="audio/mp3")
 
         # with open(st.session_state.user_audio, "rb") as f:


### PR DESCRIPTION
- fix: update packages to deploy app on render
- fix: remove storage of user voice data from demo

Heroku no longer has a free tier, so moved the app to render.com since it's the only service left that a) has a free tier and b) doesn't require credit card. Deployment process much easier than before - just need to pull docker image.